### PR TITLE
fix(misc): errors when packaging/tsc

### DIFF
--- a/src/lib/temp-filesystem-provider.ts
+++ b/src/lib/temp-filesystem-provider.ts
@@ -44,7 +44,7 @@ export class TempFileSystemProvider implements vscode.FileSystemProvider {
 				size: stats.size,
 			}
 		} catch (error) {
-			if (error.code === 'ENOENT') {
+			if (error instanceof Error && error.message.includes('ENOENT')) {
 				throw vscode.FileSystemError.FileNotFound(uri)
 			}
 			throw error

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -1,4 +1,6 @@
 export function getErrorMessage(error: unknown): string {
-	if (error instanceof Error) return error.message
+	if (error instanceof Error) {
+		return error.message
+	}
 	return String(error)
 }

--- a/src/postsProvider.ts
+++ b/src/postsProvider.ts
@@ -16,11 +16,7 @@ export class PostsProvider implements vscode.TreeDataProvider<Post> {
 		this._onDidChangeTreeData.fire()
 	}
 
-	context: vscode.ExtensionContext
-
-	constructor(private context: vscode.ExtensionContext) {
-		this.context = context
-
+	constructor(public context: vscode.ExtensionContext) {
 		extensionEvents.on('post:updated', () => this.refresh())
 		extensionEvents.on('post:created', () => this.refresh())
 		extensionEvents.on('post:published', () => this.refresh())


### PR DESCRIPTION
![g misc](https://media2.giphy.com/media/1bLfTdPis6fpC/giphy.gif?cid=0b9ef2f4x94pza7dozwnsq8u9s163pu6r59v9hbaoiaiekfq&ep=v1_gifs_search&rid=giphy.gif&ct=g)

Using the `public` keyword in the constructor is syntax sugar for:

this.context = context